### PR TITLE
Enable ESLint ES8 (async/await) parsing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+* 1.0.3 March 21, 2017
+  - Set `ecmaVersion` to 2017 to support async/await
+
 * 1.0.2 March 20, 2017
   - Disable no-use-before-define for functions and classes
 

--- a/index.js
+++ b/index.js
@@ -8,6 +8,9 @@ module.exports = {
     "airbnb-base/rules/variables",
     "airbnb-base/rules/es6",
   ],
+  parserOptions: {
+    ecmaVersion: 2017,
+  },
   "plugins": [
     "mocha"
   ],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-button-platform",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "Button Platform's eslint config",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
### Description

Forgot to set the language version earlier... We are pulling specific rules from airbnb, not extending it, to avoid ES6 imports, so we have to specify it explicitly

### Merge Checklist

- [x] Updated CHANGELOG.md
- [x] Updated version in `package.json`
- [x] Solemly swear to cut a release/tag after merge to master
