### PR TITLE
Add mocha, es6, and node to env for globals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+* 1.0.4 March 21, 2017
+  - Add environment to the base config
+
 * 1.0.3 March 21, 2017
   - Set `ecmaVersion` to 2017 to support async/await
 

--- a/index.js
+++ b/index.js
@@ -11,6 +11,11 @@ module.exports = {
   parserOptions: {
     ecmaVersion: 2017,
   },
+  "env": {
+      "es6": true,
+      "node": true,
+      "mocha": true
+  },
   "plugins": [
     "mocha"
   ],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-button-platform",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "Button Platform's eslint config",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
### Description

Make the eslint config recognize global variables we use everywhere for mocha, es6, and node, instead of having a block like the below in every project.

```
    "env": {
        "es6": true,
        "node": true,
        "mocha": true
    },
```

### Merge Checklist

- [x] Updated CHANGELOG.md
- [x] Updated version in `package.json`
- [x] Solemly swear to cut a release/tag after merge to master
