### PR TITLE
Enforce `no-multiple-empty-lines`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+* 1.1.0 July 14, 2017
+  - Rule change: Enforce `no-multiple-empty-lines`.
+
 * 1.0.4 March 21, 2017
   - Add environment to the base config
 

--- a/index.js
+++ b/index.js
@@ -154,6 +154,13 @@ module.exports = {
     "mocha/no-mocha-arrows": "error",
 
     // Either function expressions or arrow callbacks can be used
-    "prefer-arrow-callback": "off"
+    "prefer-arrow-callback": "off",
+
+    // No multiple blank lines.
+    "no-multiple-empty-lines": ["error", {
+      "max": 2,
+      "maxEOF": 1,
+      "maxBOF": 0
+    }]
   }
 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-button-platform",
-  "version": "1.0.4",
+  "version": "1.1.0",
   "description": "Button Platform's eslint config",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
### Description

Primarily I'd like to lint (and autofix) the blank lines left when `'use strict'` is auto-fixed and removed from the head of file (`maxBOF = 0`).

I can take or leave the `maxEOF` and `max` enforcement; testing it out on a large codebase didn't produce any errors, so I don't think it will be too much trouble.


### Merge Checklist

- [x] Updated CHANGELOG.md
- [x] Updated version in `package.json`
- [x] Solemly swear to cut a release/tag after merge to master
