### PR TITLE
Add lint rules to align with prettier.js

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+* 1.2.0 August 2, 2017
+  - Add prettier compatibility rules
+  - Add mocha exclusive rule
+
 * 1.1.0 July 14, 2017
   - Rule change: Enforce `no-multiple-empty-lines`.
 

--- a/index.js
+++ b/index.js
@@ -147,6 +147,7 @@ module.exports = {
     // Man line length is 100
     "max-len": ["error", 100, {
       "ignoreTemplateLiterals": true,
+      "ignoreStrings": true,
       "ignoreUrls": true,
     }],
 
@@ -161,6 +162,13 @@ module.exports = {
       "max": 2,
       "maxEOF": 1,
       "maxBOF": 0
-    }]
+    }],
+
+    // `function foo(x) {}` is okay
+    "space-before-function-paren": "off",
+
+    // `it.only`, `describe.only` et. al. will error.  Not helpful if you run
+    // your lint rule as a mocha test case itself.
+    "mocha/no-exclusive-tests": "error"
   }
 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-button-platform",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "Button Platform's eslint config",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
### Description

Adding rules to make our eslint config compatible with prettier.  If we're happy with prettier in the long term, we should cull styling rules from our eslint config altogether. 

As a bonus, adding a mocha rule to catch exclusive tests. 

### Merge Checklist

- [x] Updated CHANGELOG.md
- [x] Updated version in `package.json`
- [x] Solemly swear to cut a release/tag after merge to master
