### PR TITLE
Update ECMA to 2020

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+* 2.1.0 June 17, 2024
+  - Update ECMA version to 2020
+
 * 2.0.0 January 11, 2021
   - Scopes package to button organization
   Projects using eslint can extend the repo like so:

--- a/index.js
+++ b/index.js
@@ -9,7 +9,7 @@ module.exports = {
     "airbnb-base/rules/es6",
   ],
   parserOptions: {
-    ecmaVersion: 2018,
+    ecmaVersion: 2020,
   },
   "env": {
       "es6": true,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@button/eslint-config-button-platform",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "description": "Button Platform's eslint config",
   "main": "index.js",
   "publishConfig": {


### PR DESCRIPTION
### Description
In multiple cases recently, myself or others have attempted to use modern JavaScript features in a service only to blocked by the eslint version. These are features supported by our universal use of Node 16.3.1 but the eslint version is stuck in 2018.

### Notes
- ECMA 2020 should be mostly if not fully [supported by Node 16.3.1](https://compat-table.github.io/compat-table/es2016plus/#node16_11)
- This config is inherited by [10 different repos](https://github.com/search?q=org%3Abutton+%40button%2Feslint-config-button-platform+path%3Apackage.json&type=code) right now
- All the repos are set to install minor updates (`^`) from here so updating the version here to 2.1.0 will provide this update but still will require each repo to be manually updated (this is ideal)

### Tests
I had repo `the-tickler` open and tested this branch change by changing `devDependencies` in `package.json` to   `"@button/eslint-config-button-platform": "github.com:button/eslint-config-button-platform#mattm-ecma-2020"`
and ran `npm update @button/eslint-config-button-platform`. 
I then added a known modern JS feature (numerical separator) to a file and restarted the ESLint server and saw the warning vanish.
**Before**
![Screenshot 2024-06-17 at 11 17 17 AM](https://github.com/button/eslint-config-button-platform/assets/94390102/d3fb86bb-bd41-45b1-921c-e51fd4055944)
**After**
![Screenshot 2024-06-17 at 11 16 10 AM](https://github.com/button/eslint-config-button-platform/assets/94390102/97d86c62-b8d4-49fc-b598-6a2a65787e27)

### Merge Checklist
- [x] Updated CHANGELOG.md
- [x] Updated version in `package.json`
- [x] Solemly swear to cut a release/tag after merge to master
